### PR TITLE
Fixed subclass bug (index.name)

### DIFF
--- a/src/Kdyby/DoctrineSearch/Console/PipeEntitiesCommand.php
+++ b/src/Kdyby/DoctrineSearch/Console/PipeEntitiesCommand.php
@@ -76,6 +76,7 @@ class PipeEntitiesCommand extends Command
 		$metaFactory = $this->searchManager->getClassMetadataFactory();
 
 		/** @var \Doctrine\Search\Mapping\ClassMetadata[] $classes */
+		$allClassesForIndex = $metaFactory->getAllMetadata();
 		if ($onlyEntity = $input->getOption('entity')) {
 			$classes = [$metaFactory->getMetadataFor($onlyEntity)];
 
@@ -126,7 +127,7 @@ class PipeEntitiesCommand extends Command
 			$aliases[$original] = $alias;
 		}
 
-		foreach ($classes as $class) { //subclass bug
+		foreach ($allClassesForIndex as $class) { //subclass bug
 			if (isset($aliases[$class->getIndexName()])) {
 				$class->index->name = $aliases[$class->getIndexName()];
 			}
@@ -160,7 +161,7 @@ class PipeEntitiesCommand extends Command
 			$output->writeln('');
 		}
 
-		foreach ($classes as $class) { //subclass bug
+		foreach ($allClassesForIndex as $class) { //subclass bug
 			// fix the metadata
 			if ($old = array_search($class->getIndexName(), $aliases, TRUE)) {
 				$class->index->name = $old;

--- a/src/Kdyby/DoctrineSearch/Console/PipeEntitiesCommand.php
+++ b/src/Kdyby/DoctrineSearch/Console/PipeEntitiesCommand.php
@@ -126,12 +126,17 @@ class PipeEntitiesCommand extends Command
 			$aliases[$original] = $alias;
 		}
 
+		foreach ($classes as $class) { //subclass bug
+			if (isset($aliases[$class->getIndexName()])) {
+				$class->index->name = $aliases[$class->getIndexName()];
+			}
+		}
+
 		foreach ($classes as $class) {
 			$output->writeln('');
 
-			if (isset($aliases[$class->getIndexName()])) {
-				$output->writeln(sprintf('Redirecting data from <info>%s</info> to <info>%s</info>', $class->getIndexName(), $aliases[$class->getIndexName()]));
-				$class->index->name = $aliases[$class->getIndexName()];
+			if ($old = array_search($class->getIndexName(), $aliases, TRUE)) {
+				$output->writeln(sprintf('Redirecting data from <info>%s</info> to <info>%s</info>', $old, $class->getIndexName()));
 			}
 
 			unset($e);
@@ -140,12 +145,12 @@ class PipeEntitiesCommand extends Command
 
 			} catch (\Exception $e) { }
 
-			// fix the metadata
-			if ($old = array_search($class->getIndexName(), $aliases, TRUE)) {
-				$class->index->name = $old;
-			}
-
 			if (isset($e)) {
+				// fix the metadata
+				if ($old = array_search($class->getIndexName(), $aliases, TRUE)) {
+					$class->index->name = $old;
+				}
+
 				throw $e;
 			}
 
@@ -153,6 +158,13 @@ class PipeEntitiesCommand extends Command
 				$progress->finish();
 			}
 			$output->writeln('');
+		}
+
+		foreach ($classes as $class) { //subclass bug
+			// fix the metadata
+			if ($old = array_search($class->getIndexName(), $aliases, TRUE)) {
+				$class->index->name = $old;
+			}
 		}
 	}
 


### PR DESCRIPTION
Pokud používá subclass, tak se ti index nahradí pouze v té hlavní, ale když se importuje jiná, tak se importuje do originálního indexu, ne do nově vytvořeného.

``` php
private function commitPersisted()
    {
        $sortedDocuments = $this->sortObjects($this->scheduledForPersist);
        $client = $this->sm->getClient();

        foreach ($sortedDocuments as $entityName => $documents) {
            $classMetadata = $this->sm->getClassMetadata($entityName); //TADY se vrati index 'rohlik' 
            $client->addDocuments($classMetadata, $documents);
            $this->updatedIndexes[] = $classMetadata->getIndexName();
        }
    }
```
